### PR TITLE
fix syntax highlight issue in dark mode

### DIFF
--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -4,7 +4,7 @@
 body {
   background-color: var(--clr-bg);
   padding: 50px;
-  font: 14px/1.5 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font: 15px/1.5 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: var(--clr-text);
   font-weight:400;
 }
@@ -78,6 +78,7 @@ pre {
   border-radius: 5px;
   border: 1px solid var(--clr-code-border);
   overflow-x: auto;
+  font-size: 14px;
 }
 
 table {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -13,7 +13,11 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0px 0 20px;
 }
 
-p, ul, ol, table, pre, dl {
+// p, ul, ol, table, pre, dl {
+//   margin: 0 0 20px;
+// }
+
+p, table, pre, dl {
   margin: 0 0 20px;
 }
 

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -18,7 +18,7 @@ h1 {
 }
 
 h2, h3, h4, h5, h6 {
-  margin: 20px 0 15px;
+  margin: 20px 0 20px;
 }
 
 // p, ul, ol, table, pre, dl {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -9,12 +9,20 @@ body {
   font-weight:400;
 }
 
+// h1, h2, h3, h4, h5, h6 {
+//   margin: 0px 0 20px;
+// }
+
 h1, h2, h3, h4, h5, h6 {
-  margin: 0 0 20px;
+  margin: 10px 0 10px;
 }
 
-p, ul, ol, table, pre, dl {
-  margin: 0 0 20px;
+// p, ul, ol, table, pre, dl {
+//   margin: 0 0 20px;
+// }
+
+p, table, pre, dl {
+  margin: 10px 0 10px;
 }
 
 h1, h2, h3 {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -9,8 +9,16 @@ body {
   font-weight:400;
 }
 
-h1, h2, h3, h4, h5, h6 {
+// h1, h2, h3, h4, h5, h6 {
+//   margin: 0px 0 20px;
+// }
+
+h1 {
   margin: 0px 0 20px;
+}
+
+h2, h3, h4, h5, h6 {
+  margin: 20px 0 15px;
 }
 
 // p, ul, ol, table, pre, dl {

--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -9,20 +9,12 @@ body {
   font-weight:400;
 }
 
-// h1, h2, h3, h4, h5, h6 {
-//   margin: 0px 0 20px;
-// }
-
 h1, h2, h3, h4, h5, h6 {
-  margin: 10px 0 10px;
+  margin: 0px 0 20px;
 }
 
-// p, ul, ol, table, pre, dl {
-//   margin: 0 0 20px;
-// }
-
-p, table, pre, dl {
-  margin: 10px 0 10px;
+p, ul, ol, table, pre, dl {
+  margin: 0 0 20px;
 }
 
 h1, h2, h3 {

--- a/_sass/rouge-github.scss
+++ b/_sass/rouge-github.scss
@@ -194,7 +194,7 @@
   color: #008080;
 }
 .highlight .ow {
-  color: #000000;
+  color: var(--clr-code-bold-text);
   font-weight: bold;
 }
 .highlight .o {


### PR DESCRIPTION
Some keywords (like `in`) were hidden in the dark mode. 